### PR TITLE
fix condition builder tests after browser tab change

### DIFF
--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@axonivy/form-editor": "*",
     "@axonivy/form-editor-core": "*",
-    "@axonivy/ui-components": "~13.1.0-next.645",
-    "@axonivy/ui-icons": "~13.1.0-next.645",
-    "@axonivy/jsonrpc": "~13.1.0-next.645",
+    "@axonivy/ui-components": "~13.1.0-next.653",
+    "@axonivy/ui-icons": "~13.1.0-next.653",
+    "@axonivy/jsonrpc": "~13.1.0-next.653",
     "@tanstack/react-query": "^5.64",
     "@tanstack/react-query-devtools": "^5.64",
     "i18next": "^24.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "playwright"
       ],
       "devDependencies": {
-        "@axonivy/eslint-config": "~13.1.0-next.645",
+        "@axonivy/eslint-config": "~13.1.0-next.653",
         "@lerna-lite/cli": "^4.0.0",
         "@lerna-lite/publish": "^4.0.0",
         "@lerna-lite/run": "^4.0.0",
@@ -31,23 +31,23 @@
       "dependencies": {
         "@axonivy/form-editor": "*",
         "@axonivy/form-editor-core": "*",
-        "@axonivy/jsonrpc": "~13.1.0-next.645",
-        "@axonivy/ui-components": "~13.1.0-next.645",
-        "@axonivy/ui-icons": "~13.1.0-next.645",
+        "@axonivy/jsonrpc": "~13.1.0-next.653",
+        "@axonivy/ui-components": "~13.1.0-next.653",
+        "@axonivy/ui-icons": "~13.1.0-next.653",
         "@tanstack/react-query": "^5.64",
-        "@tanstack/react-query-devtools": "^5.74.6",
+        "@tanstack/react-query-devtools": "^5.64",
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.0.4",
         "path-browserify": "^1.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-i18next": "^15.5.1"
+        "react-i18next": "^15.4.1"
       },
       "devDependencies": {
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
-        "vite": "^6.3.3"
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -117,9 +117,9 @@
       "license": "ISC"
     },
     "node_modules/@axonivy/eslint-config": {
-      "version": "13.1.0-next.645",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.645.tgz",
-      "integrity": "sha512-dRgv1W87xAkWx0Hm2ID6t+Y3d/s8JoyVqCeb3qwewcvCvXRUtVF4WsXBCC1qIegrrenfGwH26le1QPcPOfVOfg==",
+      "version": "13.1.0-next.653",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.653.tgz",
+      "integrity": "sha512-s3P8pwRBcqrxgNWB/jwtUXJygDQYo6jansXowJ4T7zh9WArCiO11R6BrKVFZjOqvHxH8uLM+M6btXl5db/P7Iw==",
       "dev": true,
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
@@ -159,18 +159,18 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "13.1.0-next.645",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.645.tgz",
-      "integrity": "sha512-792UxwEtshKz91e7PmN2LmXW9RIkHym5tyG8NiN7It45ZWJe+PIuQKNKL40nYfetgXONm3QFdJwmOTutg7wH5Q==",
+      "version": "13.1.0-next.653",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.653.tgz",
+      "integrity": "sha512-dZcSC78BErppg7aiCxioJbtw2AgJ1de/xWtfJDybQcFRpXiZgHOP0XXBtKulUyMDDcYBc5JnocWpmAhbhW0XkA==",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "13.1.0-next.645",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.645.tgz",
-      "integrity": "sha512-RqumuJHyzer5VcPe7iHyeKw8i3lUAS+BQ0XPaCVkQeScDtGzbxak0F1A06W7+DpN69FqYxvbt57zXXEAg740Dw==",
+      "version": "13.1.0-next.653",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.653.tgz",
+      "integrity": "sha512-wEsP4JkgoMv1+h0cCSvFOssPzMvoVvpC5OMU3SeszMadSztBwNcuq7osvV8ewBz7I0gs0VVAtO3ybTjIUzyX0A==",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.7",
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "13.1.0-next.645",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.645.tgz",
-      "integrity": "sha512-yr+X7zvFETzWeEpvjsXpCTgr5A62KrIMapu/rYtyoh53bfu5PwRFa9EFpdNK99OoYhWoxd1sg958YmwlMwSvAg==",
+      "version": "13.1.0-next.653",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.653.tgz",
+      "integrity": "sha512-bfY8SfK+ohpEaxk2UTgXAKSAfxaKbOJbN6airUVXdUagv4uLLokEG9aZVfg3JNq4rN87KCr9ynyGPtKZJfZF4g==",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
     },
     "node_modules/@babel/code-frame": {
@@ -17928,7 +17928,7 @@
         "@axonivy/form-editor-protocol": "~13.1.0-next"
       },
       "devDependencies": {
-        "vite": "^6.3.3"
+        "vite": "^6.0.0"
       },
       "peerDependencies": {
         "@axonivy/jsonrpc": "~13.1.0-next"
@@ -17959,7 +17959,7 @@
         "rollup-plugin-visualizer": "^5.14.0",
         "vite-plugin-dts": "^4.5.0",
         "vite-plugin-svgr": "^4.3.0",
-        "vitest": "^3.1.2"
+        "vitest": "^3.0.3"
       },
       "peerDependencies": {
         "@axonivy/ui-components": "~13.1.0-next",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "publish:next": "lerna publish --exact --canary --preid next --tag-version-prefix beta --pre-dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes"
   },
   "devDependencies": {
-    "@axonivy/eslint-config": "~13.1.0-next.645",
+    "@axonivy/eslint-config": "~13.1.0-next.653",
     "@types/node": "^22.10.7",
     "@lerna-lite/cli": "^4.0.0",
     "@lerna-lite/publish": "^4.0.0",

--- a/playwright/tests/integration/conditionBuilder.spec.ts
+++ b/playwright/tests/integration/conditionBuilder.spec.ts
@@ -23,7 +23,7 @@ export async function applyConditionBuilder(page: Page) {
   const condition = page.locator('.ui-condition-builder-condition');
   const group = page.locator('.ui-condition-builder-group');
 
-  await expect(page.getByRole('dialog').getByRole('combobox').nth(0)).toHaveText('Basic Condition');
+  await page.getByRole('option').getByText('Basic Condition').click();
   await expect(condition).toHaveCount(1);
   await expect(condition.locator('output')).toHaveCount(2);
 


### PR DESCRIPTION
The test started failing after the following change, presumably: https://github.com/axonivy/ui-components/pull/422. Not entirely sure why though.

I will talk to Anaïs about streamlining some design choices regarding dialogs:
- Dialog title and description: I think all dialogs should have a consistent title and description using the components `<DialogHeader>` and `<DialogDescription>`. These are also necessary for accessibility through screen readers.
- Cancel button: Some dialogs have them, some don't. I think this should be consistent. Personally, I vote for removing them.