### PR TITLE
Move ui-components/icons css to integration

### DIFF
--- a/integrations/standalone/src/index.css
+++ b/integrations/standalone/src/index.css
@@ -1,3 +1,8 @@
+@layer icons;
+
+@import '@axonivy/ui-icons/src-gen/ivy-icons.css' layer(icons);
+@import '@axonivy/ui-components/lib/components.css';
+
 html,
 body,
 #root {

--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -1,4 +1,0 @@
-@layer icons;
-
-@import '@axonivy/ui-icons/src-gen/ivy-icons.css' layer(icons);
-@import '@axonivy/ui-components/lib/components.css';

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -1,5 +1,4 @@
 import { Editor, type FormEditorProps } from './editor/Editor';
-import './App.css';
 
 function App(props: FormEditorProps) {
   return <Editor {...props} />;


### PR DESCRIPTION
I will take this PR as reference, as I plan to rollout this change to all editor repos.
The reason is, that the ui-icons/ui-components are only peerDependencies on editor level. This means the integration (standalone, vscode, neo) will define the final version for them. 
This means that the output editor.css doesn't need to include the ui-components/ui-icons CSS, as it will also provided by the integration. 
It also means that before it could happen that the editor.css included styles from an old ui-components which didn't match with the current used neo version. Technically this should not make any difference, because the class names are randomized but it could happen that styles are wrong.

So to summarize, this has the effect:
- The editor.css files will be smaller, as the only contain the CSS from the editor code itself
- There should no longer be Css UI bugs because of old ui-components/ui-icons styles in the editor.css

This also means that neo, vscode and the standalone needs to add the ui-components/ui-icons styles. In neo this should anyways already be the case. But I think I need to add the styles to vscode.