### PR TITLE
XIVY-16548 Enable also Panel & Fieldset to be extracted into a component

### DIFF
--- a/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
+++ b/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
@@ -34,7 +34,7 @@ export const useFieldsetComponent = () => {
       icon: <IconSvg />,
       description: t('components.fieldset.description'),
       defaultProps: defaultFieldsetProps,
-      quickActions: DEFAULT_QUICK_ACTIONS,
+      quickActions: [...DEFAULT_QUICK_ACTIONS, 'EXTRACTINTOCOMPONENT'],
       render: props => <UiBlock {...props} />,
       create: ({ defaultProps }) => ({ ...defaultFieldsetProps, ...defaultProps }),
       outlineInfo: component => component.legend,

--- a/packages/editor/src/components/blocks/panel/Panel.tsx
+++ b/packages/editor/src/components/blocks/panel/Panel.tsx
@@ -35,7 +35,7 @@ export const usePanelComponent = () => {
       icon: <IconSvg />,
       description: t('components.panel.description'),
       defaultProps: defaultPanelProps,
-      quickActions: DEFAULT_QUICK_ACTIONS,
+      quickActions: [...DEFAULT_QUICK_ACTIONS, 'EXTRACTINTOCOMPONENT'],
       render: props => <UiBlock {...props} />,
       create: ({ defaultProps }) => ({ ...defaultPanelProps, ...defaultProps }),
       outlineInfo: component => component.title,

--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -115,7 +115,7 @@ const Draggable = ({ config, data }: DraggableProps) => {
             : undefined
         }
         extractIntoComponent={
-          config.quickActions.includes('EXTRACTINTOCOMPONENT') && data.type === 'Layout'
+          config.quickActions.includes('EXTRACTINTOCOMPONENT')
             ? { data, openDialog: showExtractDialog, setOpenDialog: setShowExtractDialog }
             : undefined
         }


### PR DESCRIPTION
feedback from bruno was that he thought it would be useful to be able to extract all structure components (i.e. layout/panel/fieldset) into one ivy component.