### PR TITLE
Remove forwardRef API usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "@axonivy/jsonrpc": "~13.1.0-next.674",
         "@axonivy/ui-components": "~13.1.0-next.674",
         "@axonivy/ui-icons": "~13.1.0-next.674",
-        "@tanstack/react-query": "^5.75.5",
-        "@tanstack/react-query-devtools": "^5.75.5",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.0.4",
         "path-browserify": "^1.0.1",
@@ -45,10 +45,10 @@
         "react-i18next": "^15.4.1"
       },
       "devDependencies": {
-        "@types/react": "^19.1.3",
+        "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
-        "vite": "^6.3.5"
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -17863,7 +17863,7 @@
         "@axonivy/form-editor-protocol": "~13.1.0-next"
       },
       "devDependencies": {
-        "vite": "^6.3.5"
+        "vite": "^6.0.0"
       },
       "peerDependencies": {
         "@axonivy/jsonrpc": "~13.1.0-next"
@@ -17884,7 +17884,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.0",
-        "@types/react": "^19.1.3",
+        "@types/react": "^19.0.7",
         "@vanilla-extract/recipes": "^0.5.5",
         "@vitejs/plugin-react": "^4.3.4",
         "i18next-parser": "^9.3.0",
@@ -17893,7 +17893,7 @@
         "react-dom": "^19.0.0",
         "vite-plugin-dts": "^4.5.0",
         "vite-plugin-svgr": "^4.3.0",
-        "vitest": "^3.1.3"
+        "vitest": "^3.0.3"
       },
       "peerDependencies": {
         "@axonivy/ui-components": "~13.1.0-next",
@@ -17901,7 +17901,7 @@
         "@tanstack/react-query": "^5.64",
         "@tanstack/react-query-devtools": "^5.64",
         "i18next": "^24.2.3",
-        "react": "^18.2 || ^19.0",
+        "react": "^19.0",
         "react-i18next": "^15.4.1"
       }
     },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,7 +26,7 @@
     "@tanstack/react-query-devtools": "^5.64",
     "i18next": "^24.2.3",
     "react-i18next": "^15.4.1",
-    "react": "^18.2 || ^19.0"
+    "react": "^19.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/editor/src/editor/FormToolbar.tsx
+++ b/packages/editor/src/editor/FormToolbar.tsx
@@ -25,7 +25,7 @@ import {
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useAppContext } from '../context/AppContext';
 import { PaletteCategoryPopover, PalettePopover } from './palette/PalettePopover';
-import { forwardRef, useMemo, useRef } from 'react';
+import { useMemo, useRef, type ComponentProps } from 'react';
 import { FormPalette } from './palette/Palette';
 import { useData } from '../data/data';
 import { CompositePalette } from './palette/composite/CompositePalette';
@@ -37,7 +37,7 @@ import { useComponents } from '../context/ComponentsContext';
 
 type DeviceMode = 'desktop' | 'tablet' | 'mobile';
 
-export const FormToolbar = forwardRef<HTMLDivElement>((_, ref) => {
+export const FormToolbar = ({ ref }: ComponentProps<'div'>) => {
   const { t } = useTranslation();
   const { allComponentsByCategory } = useComponents();
   const { ui, setUi, history, helpUrl, previewUrl } = useAppContext();
@@ -212,4 +212,4 @@ export const FormToolbar = forwardRef<HTMLDivElement>((_, ref) => {
       </Flex>
     </Toolbar>
   );
-});
+};


### PR DESCRIPTION
Since React 19, ref can be a prop so forwardRef is no longer needed