### PR TITLE
XIVY-16674 Remove ivyFormDataTableHandler prefix from Dialog-Components

### DIFF
--- a/packages/editor/src/components/blocks/button/fields/TypeField.tsx
+++ b/packages/editor/src/components/blocks/button/fields/TypeField.tsx
@@ -28,13 +28,13 @@ const TypeField = ({ label, value, onChange, validationPath }: GenericFieldProps
     setElement(element => {
       if (isButton(element)) {
         if (change === 'EDIT') {
-          element.config.action = '#{ivyFormDataTableHandler.editRow(row)}'; //just placeholder, will be set from backend
+          element.config.action = 'editRow'; //just placeholder, will be set from backend
           element.config.variant = 'PRIMARY';
           element.config.name = '';
           element.config.icon = 'pi pi-pencil';
           element.config.confirmDialog = false;
         } else if (change === 'DELETE') {
-          element.config.action = '#{ivyFormDataTableHandler.deleteRow(row)}'; //just placeholder, will be set from backend
+          element.config.action = 'deleteRow'; //just placeholder, will be set from backend
           element.config.variant = 'DANGER';
           element.config.name = '';
           element.config.icon = 'pi pi-trash';

--- a/packages/editor/src/components/blocks/datatable/fields/useEditableDataTableField.test.ts
+++ b/packages/editor/src/components/blocks/datatable/fields/useEditableDataTableField.test.ts
@@ -52,7 +52,7 @@ const dialog: ComponentData = {
 const editButton: ComponentData = {
   cid: 'button5',
   config: {
-    action: '#{ivyFormDataTableHandler.editRow(row)}', // just placeholder, will be set from backend
+    action: 'editRow', // just placeholder, will be set from backend
     alignSelf: 'START',
     confirmCancelValue: 'components.button.confirm.no',
     confirmOkValue: 'components.button.confirm.yes',
@@ -79,7 +79,7 @@ const editButton: ComponentData = {
 const deleteButton: ComponentData = {
   cid: 'button6',
   config: {
-    action: '#{ivyFormDataTableHandler.deleteRow(row)}', // just placeholder, will be set from backend
+    action: 'deleteRow', // just placeholder, will be set from backend
     alignSelf: 'START',
     confirmCancelValue: 'components.button.confirm.no',
     confirmOkValue: 'components.button.confirm.yes',

--- a/packages/editor/src/components/blocks/datatable/fields/useEditableDataTableField.ts
+++ b/packages/editor/src/components/blocks/datatable/fields/useEditableDataTableField.ts
@@ -104,13 +104,13 @@ export const useEditableDataTableField = () => {
     {
       componentName: 'Button',
       label: '',
-      value: '#{ivyFormDataTableHandler.editRow(row)}', // just placeholder, will be set from backend
+      value: 'editRow', // just placeholder, will be set from backend
       defaultProps: { type: 'EDIT', icon: 'pi pi-pencil', variant: 'PRIMARY', confirmDialog: false }
     },
     {
       componentName: 'Button',
       label: '',
-      value: `#{ivyFormDataTableHandler.deleteRow(row)}`, // just placeholder, will be set from backend
+      value: 'deleteRow', // just placeholder, will be set from backend
       defaultProps: { type: 'DELETE', icon: 'pi pi-trash', variant: 'DANGER', confirmDialog: true }
     }
   ];

--- a/packages/editor/src/components/blocks/dialog/Dialog.tsx
+++ b/packages/editor/src/components/blocks/dialog/Dialog.tsx
@@ -49,8 +49,8 @@ export const useDialogComponent = () => {
           type: 'textBrowser',
           browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
         },
-        onApply: { subsection: 'General', label: t('property.linkedComponent'), type: 'text' },
-        linkedComponent: { subsection: 'General', label: t('property.linkedComponent'), type: 'text' }
+        onApply: { subsection: 'General', label: t('property.linkedComponent'), type: 'hidden' },
+        linkedComponent: { subsection: 'General', label: t('property.linkedComponent'), type: 'hidden' }
       },
       quickActions: DEFAULT_QUICK_ACTIONS
     };
@@ -79,7 +79,7 @@ const DialogUiBlock = ({ id, components, header, linkedComponent }: UiComponentP
           creationTarget={id}
           onlyAttributs={onlyAttributs}
           showRootNode={false}
-          prefix='ivyFormDataTableHandler.currentRow'
+          prefix='currentRow'
           parentName='row'
         >
           <Button

--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.test.ts
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.test.ts
@@ -21,7 +21,7 @@ test('returns full variable path when row is defined and componentInDialog is fa
 });
 test('returns prefixed variable path when row is defined and componentInDialog is true', () => {
   const result = getApplyModifierValue(row, true);
-  expect(result).toEqual({ value: 'ivyFormDataTableHandler.currentRow.address.location.country' });
+  expect(result).toEqual({ value: 'currentRow.address.location.country' });
 });
 test('returns partial path when onlyAttributes is COLUMN and componentInDialog is false', () => {
   const result = getApplyModifierValue(row, false, { attribute: { onlyAttributes: 'COLUMN' } });
@@ -36,7 +36,7 @@ test('returns only prefix when row has no parents and componentInDialog is true'
     } as Row<BrowserNode>,
     true
   );
-  expect(result).toEqual({ value: 'ivyFormDataTableHandler.currentRow' });
+  expect(result).toEqual({ value: 'currentRow' });
 });
 
 test('returns only row value when onlyAttributes is COLUMN and row has no parents', () => {

--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
@@ -61,7 +61,7 @@ export const getApplyModifierValue = (
     return { value: '' };
   }
 
-  const prefix = componentInDialog ? 'ivyFormDataTableHandler.currentRow' : '';
+  const prefix = componentInDialog ? 'currentRow' : '';
   const path = fullVariablePath(row, (componentInDialog || options?.attribute?.onlyAttributes) && false);
 
   return { value: `${prefix}${componentInDialog && path.length > 0 ? '.' : ''}${path}` };

--- a/packages/editor/src/utils/badge-properties.test.tsx
+++ b/packages/editor/src/utils/badge-properties.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 
 describe('createBadges', () => {
   const inputValues =
-    "#{data.testData} #{logic.testLogic} #{ivy.cms.co('/Categories/agile/cssIcon')} #{el.expression} #{ivyFormDataTableHandler.currentRow.age} #{ivyFormDataTableHandler.currentRow} #{ivyFormDataTableHandler.something}";
+    "#{data.testData} #{logic.testLogic} #{ivy.cms.co('/Categories/agile/cssIcon')} #{el.expression} #{currentRow.age} #{currentRow}";
 
   test('test all badgeProperties', async () => {
     render(<InputBadge badgeProps={badgeProps} value={inputValues} className='badge-output' />);
@@ -31,22 +31,18 @@ describe('createBadges', () => {
     expect(expBadge.querySelector('i.ivy-start-program')).toBeVisible();
   });
 
-  test('test ivyFormDataTable badgeProperties', async () => {
+  test('test currentRow badgeProperties', async () => {
     render(<InputBadge badgeProps={badgeProps} value={inputValues} className='badge-output' />);
     const ivyFormBadgeAge = screen.getByText('age');
     const ivyFormBadgeCurrentRow = screen.getByText('currentRow');
-    const ivyFormBadgeSomething = screen.getByText('something');
 
     expect(ivyFormBadgeAge).toBeVisible();
     expect(ivyFormBadgeCurrentRow).toBeVisible();
-    expect(ivyFormBadgeSomething).toBeVisible();
 
     expect(ivyFormBadgeAge).toHaveTextContent('age');
     expect(ivyFormBadgeCurrentRow).toHaveTextContent('currentRow');
-    expect(ivyFormBadgeSomething).toHaveTextContent('something');
 
     expect(ivyFormBadgeAge.querySelector('i.ivy-attribute')).toBeVisible();
-    expect(ivyFormBadgeCurrentRow.querySelector('i.ivy-attribute')).toBeVisible();
-    expect(ivyFormBadgeSomething.querySelector('i.ivy-attribute')).toBeVisible();
+    expect(ivyFormBadgeCurrentRow.querySelector('i.ivy-start-program')).toBeVisible();
   });
 });

--- a/packages/editor/src/utils/badge-properties.tsx
+++ b/packages/editor/src/utils/badge-properties.tsx
@@ -15,19 +15,10 @@ const badgePropertyData: BadgeType = {
   badgeTextGen: (text: string) => text.replaceAll(/#{\s*data\.|}/g, '')
 };
 
-const badgePropertyIvyFormBean: BadgeType = {
-  regex: /#{\s*ivyFormDataTableHandler\.[^\s}]+\s*}/,
+const badgePropertyCurrentRow: BadgeType = {
+  regex: /#{\s*currentRow\.[^\s}]+\s*}/,
   icon: IvyIcons.Attribute,
-  badgeTextGen: (text: string) => {
-    const cleaned = text.replace(/^#{\s*|\s*}$/g, '');
-    if (cleaned.startsWith('ivyFormDataTableHandler.currentRow.')) {
-      return cleaned.replace('ivyFormDataTableHandler.currentRow.', '');
-    }
-    if (cleaned === 'ivyFormDataTableHandler.currentRow') {
-      return 'currentRow';
-    }
-    return cleaned.replace(/^ivyFormDataTableHandler\./, '');
-  }
+   badgeTextGen: (text: string) => text.replaceAll(/#{\s*currentRow\.|}/g, '')
 };
 
 const badgePropertyLogic: BadgeType = {
@@ -50,7 +41,7 @@ const badgePropertyExpression: BadgeType = {
 
 export const badgeProps = [
   badgePropertyData,
-  badgePropertyIvyFormBean,
+  badgePropertyCurrentRow,
   badgePropertyLogic,
   badgePropertyCMS,
   badgePropertyBean,


### PR DESCRIPTION
https://github.com/axonivy/core/pull/8878
https://github.com/axonivy/core/pull/8893

ToDo: In a later core-pr i will fix the validation errors for "currentRow" (see PrintScreen)
![grafik](https://github.com/user-attachments/assets/147f7b8a-bfd0-4d93-8991-df1903d2689c)
