### PR TITLE
XIVY-15968 Fix attr-browser to correctly handle prefix for root-row

### DIFF
--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.test.ts
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.test.ts
@@ -7,6 +7,7 @@ import type { DeepPartial } from '../../../types/types';
 
 const row = {
   original: { value: 'country', info: 'String' },
+  getParentRow: () => ({ original: { value: 'data' } }) as Row<BrowserNode>,
   getParentRows: () => [{ original: { value: 'data' } }, { original: { value: 'address' } }, { original: { value: 'location' } }]
 } as Row<BrowserNode>;
 
@@ -31,7 +32,8 @@ test('returns partial path when onlyAttributes is COLUMN and componentInDialog i
 test('returns only prefix when row has no parents and componentInDialog is true', () => {
   const result = getApplyModifierValue(
     {
-      original: { value: 'variable', info: 'String' },
+      original: { value: 'currentRow', info: 'String' },
+      getParentRow: () => undefined,
       getParentRows: () => [{}]
     } as Row<BrowserNode>,
     true

--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
@@ -60,12 +60,13 @@ export const getApplyModifierValue = (
   if (!row) {
     return { value: '' };
   }
-
-  const prefix = componentInDialog ? 'currentRow' : options?.attribute?.onlyAttributes === 'DYNAMICLIST' ? 'item' : '';
   const path = fullVariablePath(row, (componentInDialog || options?.attribute?.onlyAttributes) && false);
 
+  const hasParent = typeof row.getParentRow === 'function' && row.getParentRow();
+  const prefix = hasParent ? (componentInDialog ? 'currentRow' : options?.attribute?.onlyAttributes === 'DYNAMICLIST' ? 'item' : '') : '';
+
   return {
-    value: `${prefix}${(componentInDialog || options?.attribute?.onlyAttributes === 'DYNAMICLIST') && path.length > 0 ? '.' : ''}${path}`
+    value: `${prefix}${prefix && path ? '.' : ''}${path}`
   };
 };
 export const filterNodesWithChildren = (nodes: Array<BrowserNode<Variable>>): Array<BrowserNode<Variable>> => {
@@ -109,7 +110,7 @@ const determineTreeData = (
         const dataTable = findComponentDeep(data.components, (parentComponent.config as unknown as Dialog)?.linkedComponent);
         const table = dataTable ? dataTable.data[dataTable.index] : undefined;
         if (table && isTable(table)) {
-          return findAttributesOfType(variableInfo, stripELExpression(table.config.value), 10, 'row');
+          return findAttributesOfType(variableInfo, stripELExpression(table.config.value), 10, 'currentRow');
         }
       } else {
         return variableTreeData().of(variableInfo);


### PR DESCRIPTION
The issue previously was that when selecting the root parent via the attribute browser, the prefix was still being added. This meant that if the root was "item", it would add #{item.item} instead of just #{item}. I have now fixed this with this change.