### PR TITLE
XIVY-17063 Add Error for editable DataTables inside Component

### DIFF
--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -1,10 +1,11 @@
-import type {
-  Button as ButtonType,
-  Component,
-  ComponentData,
-  ComponentType,
-  Composite,
-  DataTableColumn
+import {
+  isTable,
+  type Button as ButtonType,
+  type Component,
+  type ComponentData,
+  type ComponentType,
+  type Composite,
+  type DataTableColumn
 } from '@axonivy/form-editor-protocol';
 import {
   Button,
@@ -96,6 +97,7 @@ const Draggable = ({ config, data }: DraggableProps) => {
             'draggable',
             isSelected && 'selected',
             isDragging && 'dragging',
+            isTable(data) && data.config.isEditable && formData.config.type === 'COMPONENT' && 'validation error',
             validations.length > 0 && `validation ${evalDotState(validations, undefined)}`
           )}
           ref={setNodeRef}

--- a/packages/editor/src/editor/sidebar/Properties.tsx
+++ b/packages/editor/src/editor/sidebar/Properties.tsx
@@ -1,4 +1,4 @@
-import type { FormType } from '@axonivy/form-editor-protocol';
+import { isTable, type FormType } from '@axonivy/form-editor-protocol';
 import {
   BasicInscriptionTabs,
   Collapsible,
@@ -6,6 +6,7 @@ import {
   CollapsibleState,
   CollapsibleTrigger,
   Flex,
+  Message,
   type InscriptionTabProps
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
@@ -26,7 +27,7 @@ import { usePropertySubSectionControl } from './PropertySubSectionControl';
 export const Properties = () => {
   const { categoryTranslations: CategoryTranslations } = useBase();
   const { componentByElement } = useComponents();
-  const { element, parent } = useData();
+  const { element, parent, data } = useData();
   const { validations } = useAppContext();
   const [value, setValue] = useState('Properties');
   if (element === undefined) {
@@ -39,9 +40,16 @@ export const Properties = () => {
 
   const tabs: InscriptionTabProps[] = [...sections].map(([, { section, fields }]) => {
     return {
-      content: groupFieldsBySubsection(fields).map(({ title, fields }) => (
-        <PropertySubSection key={title} title={CategoryTranslations[title]} fields={fields} />
-      )),
+      content: (
+        <>
+          {isTable(element) && element.config.isEditable && data.config.type === 'COMPONENT' && (
+            <Message variant='error' message='Editable DataTable is not supported inside a form component.' />
+          )}
+          {groupFieldsBySubsection(fields).map(({ title, fields }) => (
+            <PropertySubSection key={title} title={CategoryTranslations[title]} fields={fields} />
+          ))}
+        </>
+      ),
       icon: section.icon,
       id: section.name,
       name: CategoryTranslations[section.name],


### PR DESCRIPTION
Since it's currently not straightforward to support extracting an editable DataTable into a separate component—or more generally, using an editable DataTable inside a component—I’ve decided to display an error message instead.
Maybe you have a better idea for a suiting message.

This message can be removed once the editable DataTable is handled through the Dialog Framework. However, that will only be feasible once dialogs can be properly used within Ivy components, which is not yet supported at the moment.

![datatableerror](https://github.com/user-attachments/assets/2bec2d2d-abac-436d-ba57-964789053dc5)
