### PR TITLE
XIVY-17063 Fix validation if path startWith similar paths

### DIFF
--- a/packages/editor/src/context/useValidation.ts
+++ b/packages/editor/src/context/useValidation.ts
@@ -7,7 +7,7 @@ export function useValidations(path: string, options?: { exact?: boolean }): Arr
   if (options?.exact) {
     return validations.filter(val => val.path === path).map<MessageData>(toMessageData);
   }
-  return validations.filter(val => val.path.startsWith(path)).map<MessageData>(toMessageData);
+  return validations.filter(val => val.path === path || val.path.startsWith(`${path}.`)).map<MessageData>(toMessageData);
 }
 
 export function useValidation(path: string): MessageData | undefined {


### PR DESCRIPTION
Previously, there was a bug where, if you had both a dataTable1 and a dataTable14 and a validation with the path dataTable1, the validation messages for dataTable1 would also incorrectly appear on dataTable14.